### PR TITLE
supports windows 11 sdk

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,6 @@
     "@sveltejs/vite-plugin-svelte": "^1.0.1",
     "@tsconfig/svelte": "^3.0.0",
     "axios": "^0.27.2",
-    "node-sass": "^7.0.1",
     "sass": "^1.53.0",
     "svelte": "^3.49.0",
     "svelte-check": "^2.8.0",


### PR DESCRIPTION
the inclusion of node-sass was causing errors on my machine due to it forcing node to use an outdated version of gyp which didn't support the win11 sdk. it's redundant with sass anyway so it should be fine just to remove it :) (works on my machine)